### PR TITLE
feat: Button, Input, SelectBox, TextArea 범용 컴포넌트 추가

### DIFF
--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -1,0 +1,71 @@
+/** @jsxImportSource @emotion/react */
+import React from "react";
+import { css, useTheme } from "@emotion/react";
+
+// 각 Variant와 active=true 일 때 스타일
+const getVariantStyles = (theme, variant, active) => {
+  switch (variant) {
+
+    case "subsidiary": /*보조 버튼*/
+      return css`
+        background-color: ${theme.colors.white};
+        color: ${theme.colors.blue};
+        border: 1.5px solid ${theme.colors.blue};
+
+        ${active && /*보조 버튼 (active=true) */
+        css`
+          border-color: ${theme.colors.darkGray};
+          background-color: ${theme.colors.white};
+        `}
+      `;
+
+    case "secondary": /*부가 버튼*/
+      return css`
+        background-color: ${theme.colors.gray};
+        color: ${theme.colors.blue};
+        border: none;
+
+        ${active && /*부가 버튼 (active=true) */
+        css`
+          border: solid 1.5px ${theme.colors.darkGray};
+          background-color: ${theme.colors.white};
+          color: ${theme.colors.darkGray}
+        `}
+      `;
+
+    default: /*기본 버튼 (active=true) */
+      return css`
+      ${active &&
+        css`
+          background-color: ${theme.colors.lightBlue};
+          color: ${theme.colors.blue};
+      `}
+    `;
+  }
+};
+
+// 기본 버튼 스타일
+const Button = ({ children, variant, active, ...rest }) => {
+  const theme = useTheme();
+
+  const buttonStyles = css`
+    ${theme.typography.paragraph.p2}
+    font-family: ${theme.typography.fontFamily};
+    background-color: ${theme.colors.blue};
+    color: ${theme.colors.white};
+    border: none;
+    padding: 5px 22px;
+    border-radius: 50px;
+    cursor: pointer;
+
+    ${getVariantStyles(theme, variant, active)} 
+  `;
+
+  return (
+    <button css={buttonStyles} {...rest}>
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/common/Input.jsx
+++ b/src/components/common/Input.jsx
@@ -1,0 +1,93 @@
+/** @jsxImportSource @emotion/react */
+import React from "react";
+import { css, useTheme } from "@emotion/react";
+import { Placeholder } from "@untitledui/icons";
+
+// 각 Variant 스타일
+const getVariantStyles = (theme, variant) => {
+  switch (variant) {
+
+    case "id": /*아이디 입력 칸*/
+      return {
+        styles: css`
+          background-color: ${theme.colors.white};
+        `,
+        placeholder: "아이디를 입력하세요", 
+      };
+
+
+    case "password": /*비밀번호 입력 칸*/
+      return {
+        styles : css`
+        background-color: ${theme.colors.white};
+      `,
+        placeholder:"비밀번호를 입력하세요"
+      }
+
+    default:
+      return {
+        styles: css`
+    `,
+      placeholder: "텍스트를 입력하세요"
+    }
+  }
+};
+
+// 기본 입력 칸 스타일
+const Input = ({ variant,inactive,value, onChange, isError,...rest }) => {
+  const theme = useTheme();
+
+  const variantProps = getVariantStyles(theme, variant);
+
+  const inputStyles = css`
+    ${theme.typography.paragraph.p1}
+    font-family: ${theme.typography.fontFamily};  
+    box-sizing: border-box;
+    width:300px;
+    height:44px;
+    padding: 4px 5px 4px 18px;
+    border-radius: 10px;
+    border: solid 1px ${theme.colors.darkGray};
+    background-color: ${theme.colors.white};
+    color: ${theme.colors.black};
+
+    ${inactive && /*비활성화 상태*/
+      css`
+        background-color: ${theme.colors.gray};
+        color: ${theme.colors.darkGray}
+    `}
+
+    ${isError &&
+      css`
+        border-color: ${theme.colors.red}
+    `}
+
+    &:focus {
+    outline: none;
+    border: 1px solid ${isError ? theme.colors.red : theme.colors.blue};
+
+    ${variantProps.styles}
+
+    &::placeholder {
+    color: ${theme.colors.darkGray};
+    };
+  `;
+
+  return (
+    <div style={{ position: 'relative', width: '300px' }}>
+      <input 
+        css={css` ${inputStyles} padding-right: 40px; `}
+        placeholder={variantProps.placeholder}{...rest}
+      />
+      {isError && (
+      <div style={{
+          position: 'absolute', right: '12px', top: '50%', transform: 'translateY(-50%)', color: '#AC182D'
+      }}>
+        ※
+      </div>
+    )}
+    </div>
+  );
+};
+
+export default Input;

--- a/src/components/common/SelectBox.jsx
+++ b/src/components/common/SelectBox.jsx
@@ -1,0 +1,101 @@
+/** @jsxImportSource @emotion/react */
+import React, { useState } from "react";
+import { css, useTheme } from "@emotion/react";
+
+// 항목 데이터
+const options = [
+  "옵션-default",
+  "옵션-hover",
+  "옵션-pressed",
+  "옵션-selected",
+  "옵션",
+];
+
+const Dropdown = () => {
+  const theme = useTheme();
+
+  const [isOpen, setIsOpen] = useState(false); // 드롭다운 열림, 닫힘 상태
+  const [selectedOption, setSelectedOption] = useState(null); // 선택된 옵션 상태
+
+  const handleToggle = () => setIsOpen(!isOpen);
+
+  const handleOptionClick = (option) => {
+    setSelectedOption(option); // 옵션 선택
+    setIsOpen(false); // 드롭다운 닫기
+  };
+
+  const dropdownContainerStyles = css`
+    position: relative; 
+    width: 360px;
+    font-family: ${theme.typography.fontFamily};
+    ${theme.typography.paragraph.p2}
+    color: ${theme.colors.black};
+  `;
+
+  const dropdownButtonStyles = css`
+    box-sizing: border-box;
+    height: 48px;
+    padding: 0px 18px;
+    border: solid 2px ${theme.colors.blue};
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    cursor: pointer;
+    background-color: ${theme.colors.white};
+    ${theme.typography.paragraph.p2};
+  `;
+
+  const dropdownContentStyles = css`
+    position: absolute;
+    top: calc(100%);
+    left: 0;
+    right: 0;
+    background-color: ${theme.colors.white};
+    border: solid 1px ${theme.colors.darkGray};
+    border-radius: 10px;
+    z-index: 10;
+    padding: 8px;
+  `;
+  
+  // isSelected에 따라 스타일을 적용
+  const dropdownItemStyles = (isSelected) => css`
+    padding: 10px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+    /* 기본 상태 */
+    background-color: ${theme.colors.white};
+    color: ${isSelected ? theme.colors.blue : theme.colors.black};
+    
+    /* 마우스 올렸을 때 */
+    &:hover {
+      background-color: ${theme.colors.lightBlue};
+    }
+  `;
+
+  return (
+    <div css={dropdownContainerStyles}>
+      <div css={dropdownButtonStyles} onClick={handleToggle}>
+        <div>{selectedOption || "선택해주세요."}</div>
+        <div>{isOpen ? "∧" : "∨"}</div>
+      </div>
+
+      /* isOpen이 true일 때 */
+      {isOpen && (
+        <div css={dropdownContentStyles}>
+          {options.map((option) => (
+            <div
+              key={option}
+              css={dropdownItemStyles(selectedOption === option)}
+              onClick={() => handleOptionClick(option)}
+            >
+              {selectedOption === option && "✓ "}{option}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Dropdown;

--- a/src/components/common/TextArea.jsx
+++ b/src/components/common/TextArea.jsx
@@ -1,0 +1,50 @@
+/** @jsxImportSource @emotion/react */
+import React from "react";
+import { css, useTheme } from "@emotion/react";
+
+const TextArea = ({
+  value,
+  onChange, /*글자가 바뀌었는지 확인*/
+  placeholder,
+  ...rest 
+}) => {
+  const theme = useTheme();
+
+  const containerStyles = css`
+    position: relative;
+    width: 100%;
+  `;
+
+  const textareaStyles = css`
+    width: 100%;
+    min-height: 160px;
+    padding: 12px 16px;
+    box-sizing: border-box;
+    border: 1px solid ${theme.colors.black};
+    border-radius: 10px;
+    background-color: ${theme.colors.white};
+    font-family: ${theme.typography.fontFamily};
+    ${theme.typography.paragraph.p3}
+    color: ${theme.colors.black};
+    resize: none;
+    outline: none;
+
+    &::placeholder {
+      color: ${theme.colors.darkGray};
+    }
+  `;
+
+  return (
+    <div css={containerStyles}>
+      <textarea
+        css={textareaStyles}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        {...rest}
+      />
+    </div>
+  );
+};
+
+export default TextArea;


### PR DESCRIPTION
범용 컴포넌트 4가지 ( 버튼, 입력, 드롭다운. 여러줄 입력 )를 추가했습니다. 

**1. Button**
- 'variant' prop을 통해 기본 포함 3가지 스타일 버튼을 사용가능합니다.
- 'active' prop으로 활성화 상태를 나타낼 수 있습니다.
<img width="658" height="115" alt="Button" src="https://github.com/user-attachments/assets/cca3b024-942c-4b61-b10b-6291b529b811" />


**2. Input**
- 'isError' prop이 ture일 때, 테두리가 빨간색으로 변경되고 에러 아이콘이 표시됩니다.
- 'inactive' prop으로 비활성화 상태를 지원합니다.
<img width="422" height="312" alt="input" src="https://github.com/user-attachments/assets/561fba54-d82a-42d7-976b-a68cac455e8b" />


**3. SelectBox (Dropdown)**
- 자체적으로 열림/선택 상태를 관리하는 드롭다운 메뉴입니다.
<img width="507" height="402" alt="SelectBox" src="https://github.com/user-attachments/assets/7dd71e06-1174-4e52-958f-f3f531feefd6" />


**4.TextArea**
- 여러 줄 텍스트 입력을 위한 제어 컴포넌트입니다.
- 100% 너비로 구현되어 부모 컨테이너의 크기에 따라갑니다.
<img width="665" height="244" alt="TextArea" src="https://github.com/user-attachments/assets/f6c38f4c-555f-42f0-b5af-5851d04f8e89" />



**5.** 
현재 아이콘 대신 텍스트로 넣어놨는데, 추후 아이콘으로 교체하겠습니다! 