### PR TITLE
feat: My페이지-내 리스트 관리 기능 구현

### DIFF
--- a/src/components/My/MyListDetail/MyListDetail.jsx
+++ b/src/components/My/MyListDetail/MyListDetail.jsx
@@ -1,0 +1,48 @@
+// --- 라이브러리 ---
+import React from "react";
+import { useParams } from "react-router-dom";
+import styled from "@emotion/styled";
+
+// --- 스타일 ---
+const StyledContainer = styled.div`
+  padding: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+const StyledTitle = styled.h2`
+  font-size: 22px;
+  font-weight: bold;
+  color: #27509B;
+  margin-bottom: 12px;
+`;
+
+const StyledStoreCard = styled.div`
+  background: #fff;
+  border: 1px solid #e9e9e9;
+  border-radius: 12px;
+  padding: 20px;
+  min-height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #b1b1b1;
+  font-size: 14px;
+`;
+
+export default function MyListDetail() {
+  // --- 내부 상태/훅 ---
+  const { id } = useParams();
+
+  // --- 렌더링 ---
+  return (
+    <StyledContainer>
+      <StyledTitle>리스트 상세 (ID: {id})</StyledTitle>
+
+      <StyledStoreCard>여기에 가게 정보가 표시될 예정입니다.</StyledStoreCard>
+      <StyledStoreCard>여기에 가게 정보가 표시될 예정입니다.</StyledStoreCard>
+      <StyledStoreCard>여기에 가게 정보가 표시될 예정입니다.</StyledStoreCard>
+    </StyledContainer>
+  );
+}

--- a/src/components/My/MyListDetail/index.js
+++ b/src/components/My/MyListDetail/index.js
@@ -1,0 +1,1 @@
+export { default as MyListDetail } from './MyListDetail';

--- a/src/components/My/MyListSection/MyListSection.jsx
+++ b/src/components/My/MyListSection/MyListSection.jsx
@@ -1,0 +1,267 @@
+// --- 라이브러리 ---
+import React, { useState } from "react";
+import styled from "@emotion/styled";
+import { useNavigate } from "react-router-dom";
+
+// --- 내부 공용 컴포넌트 ---
+import { Button } from "../../common/Button";
+import { Input } from "../../common/Input";
+
+// --- 스타일 ---
+const StyledContainer = styled.div`
+  flex: 1;
+  padding: 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const StyledCardWrapper = styled.div`
+  width: 700px;
+  background: #ffffff;
+  border: 1px solid #f2f2f2;
+  border-radius: 12px;
+  padding: 32px;
+`;
+
+const StyledTitle = styled.h2`
+  font-size: 20px;
+  font-weight: bold;
+  color: #27509B;
+  margin-bottom: 24px;
+  border-bottom: 1px solid #27509B;
+  padding-bottom: 12px;
+`;
+
+const StyledListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: stretch;
+`;
+
+const StyledListCard = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-radius: 8px;
+  background: #ffffff;
+  border: 1px solid #e9e9e9;
+  cursor: pointer;
+  &:hover {
+    background: #f2f2f2;
+  }
+`;
+
+const StyledLeftSection = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+`;
+
+const StyledIcon = styled.div`
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: ${({ $color }) => $color || "#ffffff"};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+`;
+
+const StyledName = styled.div`
+  font-size: 16px;
+  font-weight: 500;
+`;
+
+const StyledCount = styled.div`
+  font-size: 13px;
+  color: #b1b1b1;
+`;
+
+const StyledAddListButton = styled(StyledListCard)`
+  justify-content: center;
+  color: #121212;
+  font-weight: 300;
+  font-size: 15px;
+  align-items: center;
+`;
+
+const StyledDeleteButton = styled.button`
+  border: none;
+  background: transparent;
+  color: #ac182d;
+  font-size: 13px;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const StyledModalOverlay = styled.div`
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const StyledModalContent = styled.div`
+  background: white;
+  padding: 24px;
+  border-radius: 12px;
+  width: 400px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const StyledModalTitle = styled.h3`
+  font-size: 18px;
+  font-weight: bold;
+`;
+
+const StyledColorOptions = styled.div`
+  display: flex;
+  gap: 12px;
+  justify-content: left;
+`;
+
+const StyledColorCircle = styled.div`
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: ${({ $color }) => $color};
+  border: 2px solid ${({ $selected }) => ($selected ? "#ffffff" : "transparent")};
+  cursor: pointer;
+`;
+
+const StyledModalButtons = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+`;
+
+export default function MyListSection() {
+  // --- 내부 상태/훅 ---
+  const [listsState, setListsState] = useState(initialLists);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [newListNameState, setNewListNameState] = useState("");
+  const [newListColorState, setNewListColorState] = useState(colorPalette[0]);
+
+  const navigate = useNavigate();
+
+  // --- 핸들러 ---
+  const handleOpenModal = () => {
+    setNewListNameState("");
+    setNewListColorState(colorPalette[0]);
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => setIsModalOpen(false);
+
+  const handleConfirm = () => {
+    if (!newListNameState.trim()) return;
+    const newId = listsState.length + 1;
+    const newList = {
+      id: newId,
+      name: newListNameState,
+      count: 0,
+      color: newListColorState,
+    };
+    setListsState([...listsState, newList]);
+    handleCloseModal();
+  };
+
+  const handleDelete = (id) => {
+    setListsState(listsState.filter((list) => list.id !== id));
+  };
+
+  // --- 렌더링 ---
+  return (
+    <StyledContainer>
+      <StyledCardWrapper>
+        <StyledTitle>내 리스트 관리</StyledTitle>
+        
+        <StyledListContainer>
+          {listsState.map((list) => (
+            <StyledListCard
+              key={list.id}
+              onClick={() => navigate(`/my/lists/${list.id}`)}
+            >
+              <StyledLeftSection>
+                <StyledIcon $color={list.color}>♥</StyledIcon>
+                <div>
+                  <StyledName>{list.name}</StyledName>
+                  <StyledCount>개수 {list.count}</StyledCount>
+                </div>
+              </StyledLeftSection>
+              <StyledDeleteButton
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleDelete(list.id);
+                }}
+              >
+                삭제
+              </StyledDeleteButton>
+            </StyledListCard>
+          ))}
+
+          <StyledAddListButton onClick={handleOpenModal}>
+            새 리스트 추가 +
+          </StyledAddListButton>
+        </StyledListContainer>
+      </StyledCardWrapper>
+
+      {/* 모달 */}
+      {isModalOpen && (
+        <StyledModalOverlay>
+          <StyledModalContent>
+            <StyledModalTitle>새 리스트 추가</StyledModalTitle>
+
+            <Input
+              variant="text"
+              placeholder="리스트 이름을 입력하세요"
+              value={newListNameState}
+              onChange={(e) => setNewListNameState(e.target.value)}
+              width="100%"
+            />
+
+            <StyledColorOptions>
+              {colorPalette.map((color) => (
+                <StyledColorCircle
+                  key={color}
+                  $color={color}
+                  $selected={newListColorState === color}
+                  onClick={() => setNewListColorState(color)}
+                />
+              ))}
+            </StyledColorOptions>
+
+            <StyledModalButtons>
+              <Button variant="secondary" onClick={handleCloseModal}>
+                취소
+              </Button>
+              <Button variant="primary" onClick={handleConfirm}>
+                추가
+              </Button>
+            </StyledModalButtons>
+          </StyledModalContent>
+        </StyledModalOverlay>
+      )}
+    </StyledContainer>
+  );
+}
+
+// --- 초기 더미 데이터 ---
+const initialLists = [
+  { id: 1, name: "가고 싶은 한식 맛집!", count: 26, color: "#ac182d" },
+  { id: 2, name: "가고 싶은 양식 맛집!", count: 26, color: "#27509b" },
+  { id: 3, name: "가고 싶은 중식 맛집!", count: 26, color: "#d4e7fa" },
+];
+
+const colorPalette = ["#ac182d", "#27509b", "#d4e7fa", "#b1b1b1", "#121212"];

--- a/src/components/My/MyListSection/index.js
+++ b/src/components/My/MyListSection/index.js
@@ -1,0 +1,1 @@
+export { default as MyListSection } from './MyListSection';

--- a/src/components/My/UserInfoSection/UserInfoSection.jsx
+++ b/src/components/My/UserInfoSection/UserInfoSection.jsx
@@ -4,6 +4,7 @@ import styled from "@emotion/styled";
 
 // --- 내부 ---
 import { Button } from "../../common/Button";
+import { Input } from "../../common/Input";
 
 // --- 스타일 ---
 const Container = styled.div`
@@ -14,7 +15,7 @@ const Container = styled.div`
 `;
 
 const Card = styled.div`
-  width: 500px;
+  width: 700px;
   background: #ffffff;
   border: 1px solid #f2f2f2;
   border-radius: 12px;
@@ -83,28 +84,12 @@ const Stats = styled.div`
 
 const FormGroup = styled.div`
   margin-bottom: 16px;
-  width: 95%;
+  width: 100%;
 `;
 
 const Label = styled.div`
-  font-size: 14px;
-  font-weight: bold;
+  font-size: 16px;
   margin-bottom: 6px;
-`;
-
-const Input = styled.input`
-  width: 100%;
-  padding: 8px 12px;
-  font-size: 14px;
-  border: 1px solid #d9d9d9;
-  border-radius: 6px;
-
-  ${({ readOnly }) =>
-    readOnly &&
-    `
-    background: #f9f9f9;
-    color: #b1b1b1;
-  `}
 `;
 
 const ButtonRow = styled.div`
@@ -141,7 +126,7 @@ const ModalOverlay = styled.div`
 `;
 
 const ModalBox = styled.div`
-  background: #fff;
+  background: #ffffff;
   border-radius: 12px;
   padding: 24px;
   width: 400px;
@@ -182,11 +167,11 @@ export default function UserInfoSection({
   initialData = {
     intro: "인슐랭 화이팅!",
     name: "김지후",
-    nickname: "김지후",
+    nickname: "kimjihu",
     id: "incherin",
     password: "********",
-    followers: 0,
-    following: 0,
+    followers: 100,
+    following: 100,
     profileImage: null,
   },
 }) {
@@ -197,8 +182,8 @@ export default function UserInfoSection({
 
   const fileInputRef = useRef(null);
 
-  const handleChange = (e) => {
-    setUser({ ...user, [e.target.name]: e.target.value });
+  const handleChange = (field, value) => {
+    setUser({ ...user, [field]: value });
   };
 
   const handleToggle = () => {
@@ -273,26 +258,27 @@ export default function UserInfoSection({
             variant="subsidiary"
             style={{ fontSize: 12, padding: "6px 10px", height: "auto" }}
             onClick={() => fileInputRef.current.click()}
-            >
+          >
             사진 변경
-            </Button>
-            <Button
-              variant="secondary"
-              style={{ fontSize: 12, padding: "6px 10px", height: "auto" }}
-              onClick={handleImageDelete}
-              >
-              사진 삭제
-            </Button>
+          </Button>
+          <Button
+            variant="secondary"
+            style={{ fontSize: 12, padding: "6px 10px", height: "auto" }}
+            onClick={handleImageDelete}
+          >
+            사진 삭제
+          </Button>
         </ProfileButtonRow>
 
         {/* 한 줄 소개 */}
         <FormGroup>
           <Label>한 줄 소개</Label>
           <Input
-            name="intro"
+            variant="text"
             value={user.intro}
-            onChange={handleChange}
-            readOnly={!editMode}
+            onChange={(e) => handleChange("intro", e.target.value)}
+            inactive={!editMode}
+            width="100%"
           />
         </FormGroup>
 
@@ -300,10 +286,11 @@ export default function UserInfoSection({
         <FormGroup>
           <Label>이름</Label>
           <Input
-            name="name"
+            variant="text"
             value={user.name}
-            onChange={handleChange}
-            readOnly={!editMode}
+            onChange={(e) => handleChange("name", e.target.value)}
+            inactive={!editMode}
+            width="100%"
           />
         </FormGroup>
 
@@ -311,28 +298,35 @@ export default function UserInfoSection({
         <FormGroup>
           <Label>닉네임</Label>
           <Input
-            name="nickname"
+            variant="text"
             value={user.nickname}
-            onChange={handleChange}
-            readOnly={!editMode}
+            onChange={(e) => handleChange("nickname", e.target.value)}
+            inactive={!editMode}
+            width="100%"
           />
         </FormGroup>
 
         {/* 아이디 */}
         <FormGroup>
           <Label>아이디</Label>
-          <Input name="id" value={user.id} readOnly />
+          <Input
+            variant="id"
+            value={user.id}
+            inactive={true}
+            width="100%"
+          />
         </FormGroup>
 
         {/* 비밀번호 */}
         <FormGroup>
           <Label>비밀번호</Label>
           <Input
+            variant="password"
             type="password"
-            name="password"
             value={user.password}
-            onChange={handleChange}
-            readOnly={!editMode}
+            onChange={(e) => handleChange("password", e.target.value)}
+            inactive={!editMode}
+            width="100%"
           />
         </FormGroup>
 
@@ -351,13 +345,14 @@ export default function UserInfoSection({
             <Button
               variant="secondary"
               style={{
-              border: "1px solid #ac182d",
-              color: "#ac182d",
-              backgroundColor: "#ffffff",
+                border: "1px solid #ac182d",
+                color: "#ac182d",
+                backgroundColor: "#ffffff",
               }}
-              onClick={() => setShowDeleteModal(true)}>
+              onClick={() => setShowDeleteModal(true)}
+            >
               회원 탈퇴
-            </Button> 
+            </Button>
           </RightButtons>
         </ButtonRow>
       </Card>

--- a/src/components/My/index.js
+++ b/src/components/My/index.js
@@ -1,1 +1,2 @@
-export { UserInfoSection } from './UserInfoSection';
+export { default as UserInfoSection } from '../../components/My/UserInfoSection';
+export { default as MyListSection } from '../../components/My/MyListSection';

--- a/src/layouts/Sidebar.jsx
+++ b/src/layouts/Sidebar.jsx
@@ -1,4 +1,3 @@
-// Sidebar.jsx
 import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
@@ -223,12 +222,12 @@ export default function Sidebar({
           name: 'MY 페이지',
           isActive: true,
           icon: userIcon,
-          path: '/mypage',
+          path: '/my',
           hasDetail: true,
           details: [
-            { name: '내 정보', path: '/mypage/info' },
-            { name: '내가 쓴 리뷰', path: '/mypage/reviews' },
-            { name: '내 리스트 관리', path: '/mypage/lists' },
+            { name: '내 정보', path: '/my/info' },
+            { name: '내가 쓴 리뷰', path: '/my/reviews' },
+            { name: '내 리스트 관리', path: '/my/lists' },
           ],
         },
       ],

--- a/src/pages/My/index.jsx
+++ b/src/pages/My/index.jsx
@@ -1,18 +1,17 @@
-//---라이브러리---
-import React from "react";
-import { UserInfoSection } from "../../components/My";
-//---내부(현재)---
+// --- 라이브러리 ---
+import { Outlet } from "react-router-dom";
+// --- 내부 ---
 import Sidebar from "../../layouts/Sidebar";
 
 export default function MyPage() {
   return (
     <div style={{ display: "flex", height: "100vh" }}>
       {/* 왼쪽 사이드바 */}
-      <Sidebar userType="user" nickname="" />
+      <Sidebar userType="user" nickname="김지후" />
 
       {/* 오른쪽 메인 영역 */}
-      <div style={{ flex: 1, display: "flex", justifyContent: "center", alignItems: "center" }}>
-        <UserInfoSection />
+      <div style={{ flex: 1, overflowY: "auto", padding: "20px", scrollbarWidth: "none", msOverflowStyle: "none",}}>
+        <Outlet />
       </div>
     </div>
   );

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -30,6 +30,11 @@ const StoreDetailPage = lazy(() => import('../pages/StoreDetail'));
 const MyPage = lazy(() => import('../pages/My'));
 const AdminPage = lazy(() => import('../pages/Admin'));
 
+// --- My 내부 섹션 ---
+const UserInfoSection = lazy(() => import('../components/My/UserInfoSection/UserInfoSection'));
+const MyList = lazy(() => import('../components/My/MyListSection/MyListSection'));
+const MyListDetail = lazy(() => import('../components/My/MyListDetail/MyListDetail'));
+
 // --- 보호 라우트 (문서: 보호 라우트) ---
 // - 인증이 필요한 경로에서 사용
 // - 인증되지 않은 경우 AUTH 경로로 리다이렉트
@@ -59,13 +64,17 @@ const router = createBrowserRouter([
         path: ROUTES.STORE_DETAIL(),
         element: withSuspense(<StoreDetailPage />),
       },
-      {
-        path: ROUTES.MY,
-        element: withSuspense(
-          <Protected>
+      { path: ROUTES.MY, element: withSuspense(
+          //<Protected>
             <MyPage />
-          </Protected>
+          //</Protected>
         ),
+        children: [
+        { index: true, element: <Navigate to="info" replace /> },
+        { path: "info", element: withSuspense(<UserInfoSection />) },
+        { path: "lists", element: withSuspense(<MyList />) },
+        { path: "lists/:id", element: withSuspense(<MyListDetail />) },
+]
       },
       { path: ROUTES.ADMIN, element: withSuspense(<AdminPage />) },
       { path: ROUTES.NOT_FOUND, element: withSuspense(<NotFoundPage />) },


### PR DESCRIPTION
1. AppRouter 내 MyPage 하위 라우트 구조를 세분화했습니다.  
   기존 My 경로에 있던 Protected 래퍼는 화면 확인을 위해 주석 처리했으며,  
   추후 auth 연동 시 다시 활성화할 예정입니다.

2. MyListSection에서는 리스트를 추가하고 삭제할 수 있도록 구현했습니다.

3. 각 리스트 카드를 클릭하면 useNavigate를 통해 `/my/lists/:id` 경로로 이동합니다.

4. MyListDetail은 추후 가게 상세 페이지에서 사용하는 가게 정보 컴포넌트를 받아 렌더링,  각 가게 카드 클릭 시 해당 가게 상세 페이지로 이동하도록 수정할 계획입니다.

-리스트 추가-
<img width="2040" height="1100" alt="L1" src="https://github.com/user-attachments/assets/794fe552-4c1a-4338-8ac5-27dc66556430" />
-클릭 시 상세 페이지로 이동-
<img width="2040" height="1102" alt="L2" src="https://github.com/user-attachments/assets/33cfbc29-a1c1-4664-b7e5-b3542c8ccc6f" />
<img width="2028" height="1100" alt="L3" src="https://github.com/user-attachments/assets/fdb948a2-132f-44a1-9755-26bac1040004" />
-리스트 삭제-
<img width="2034" height="1096" alt="L4" src="https://github.com/user-attachments/assets/70a54124-62eb-43c1-b973-63552ffe4ca2" />
<img width="2030" height="1098" alt="L5" src="https://github.com/user-attachments/assets/048685df-d903-4424-ac97-f39da49a5f40" />
