### PR TITLE
Feature/가게 상세 페이지에 사용할 컴포넌트 중 일부 구현

### DIFF
--- a/src/components/StoreDetail/StoreDetailHeader/StoreDetailHeader.jsx
+++ b/src/components/StoreDetail/StoreDetailHeader/StoreDetailHeader.jsx
@@ -1,0 +1,270 @@
+// --- 라이브러리 ---
+import React, { useState } from 'react';
+import styled from '@emotion/styled';
+import { Phone, Heart, Share01, Star01, MarkerPin01, XClose } from '@untitledui/icons';
+
+// --- 내부 (부모) ---
+import { Button } from '../../common';
+import FoodImg from '../../../assets/image/food.webp';
+
+// --- 스타일 ---
+const Section = styled.section(({ theme }) => ({
+  width: '100%',
+  backgroundColor: theme.colors.blue,
+  padding: '35px 24px',
+  color: theme.colors.white,
+  boxSizing: 'border-box',
+}));
+const Container = styled.div`
+  max-width: 890px;
+  margin: 0 auto;
+  display: flex;
+  gap: 32px;
+  align-items: center;
+`;
+const ImageWrapper = styled.div`
+  flex-shrink: 0;
+`;
+const StyledImage = styled.img`
+  width: 300px;
+  height: 300px;
+  border-radius: 12px;
+  object-fit: cover;
+`;
+const InfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+const TitleRow = styled.div`
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+`;
+const Name = styled.h1`
+  margin: 0;
+  font-size: 32px;
+  font-weight: 700;
+`;
+const Category = styled.span`
+  font-size: 18px;
+`;
+const Description = styled.p`
+  margin: 0;
+  opacity: 0.9;
+  font-size: 16px;
+`;
+const Tags = styled.div`
+  margin-top: -8px;
+  opacity: 0.9;
+  font-size: 17px;
+  font-weight: 500;
+`;
+const AiSummary = styled.div(({ theme }) => ({
+  backgroundColor: theme.colors.white,
+  color: theme.colors.black,
+  padding: '11px 16px',
+  borderRadius: '8px',
+  width: '100%',
+  boxSizing: 'border-box',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  strong: {
+    color: theme.colors.blue,
+    fontSize: '16px',
+    fontWeight: 600,
+    flexShrink: 0,
+  },
+  p: {
+    margin: 0,
+    fontSize: '15px',
+    lineHeight: 1.6,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+}));
+const MetaRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 17px;
+`;
+const MetaItem = styled.span`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  & > svg {
+    transform: translateY(1px);
+  }
+`;
+const UnderlinedMetaItem = styled(MetaItem)`
+  text-decoration: underline;
+  cursor: pointer;
+  font-size: 15px;
+`;
+const ActionRow = styled.div`
+  display: flex;
+  gap: 12px;
+  margin-top: 8px;
+`;
+const ActionButton = styled(Button)`
+  font-size: 17px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 17px;
+  font-weight: 590;
+`;
+
+// --- 전화번호 모달 스타일 ---
+const PhoneNumberModalBackdrop = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+`;
+
+const PhoneNumberModalContent = styled.div(({ theme }) => ({
+  position: 'relative',
+  backgroundColor: theme.colors.white,
+  padding: '32px 48px',
+  borderRadius: '16px',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: '12px',
+}));
+
+const PhoneNumberModalCloseButton = styled.button`
+  position: absolute;
+  top: 10px;
+  right: 7px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #aaa;
+`;
+
+const PhoneNumberModalText = styled.p`
+  margin: 0;
+  font-size: 18px;
+  font-weight: 580;
+  color: #333;
+`;
+
+const PhoneNumberModalCopyLink = styled.button(({ theme }) => ({
+  background: 'none',
+  border: 'none',
+  color: theme.colors.blue,
+  textDecoration: 'underline',
+  cursor: 'pointer',
+  fontSize: '16px',
+}));
+
+
+// --- 기본 더미 데이터 ---
+const defaultStoreData = {
+  imageUrl: FoodImg,
+  name: '백소정 인하대후문점',
+  category: '일식당',
+  description: '백번 먹어도 정성스럽고 푸짐한 음식을 즐겁게 맛볼 수 있는 곳',
+  tags: ['#메밀소바맛집', '#인하대일식'],
+  rating: 4.9,
+  reviewCount: 21,
+  likeCount: 231,
+  distance: '451m',
+  isDelivery: true,
+  aiSummary:
+    '이 가게는 바삭한 돈까스와 시원한 메밀소바가 인기 메뉴입니다. 학생들이 가성비 좋게 즐길 수 있어 인기가 많습니다.',
+  phone: '010-1234-5678',
+};
+
+/**
+ * @param {object} props
+ * @param {object} props.store - 가게 데이터 객체
+ */
+export function StoreDetailHeader({ store = defaultStoreData }) {
+  const MAX_LENGTH = 34;
+  const summaryText =
+    store.aiSummary.length > MAX_LENGTH
+      ? `${store.aiSummary.substring(0, MAX_LENGTH)}...`
+      : store.aiSummary;
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleOpenModal = () => setIsModalOpen(true);
+  const handleCloseModal = () => setIsModalOpen(false);
+
+  const handleCopyPhoneNumber = () => {
+    navigator.clipboard.writeText(store.phone)
+      .then(() => {
+        alert('전화번호가 복사되었습니다.');
+        handleCloseModal();
+      })
+      .catch(err => {
+        console.error('복사 실패:', err);
+        alert('전화번호 복사에 실패했습니다.');
+      });
+  };
+
+  return (
+    <>
+      <Section>
+        <Container>
+          <ImageWrapper>
+            <StyledImage src={store.imageUrl} alt={store.name} />
+          </ImageWrapper>
+
+          <InfoWrapper>
+            <TitleRow>
+              <Name>{store.name}</Name>
+              <Category>{store.category}</Category>
+            </TitleRow>
+
+            <Description>{store.description}</Description>
+            <Tags>{store.tags.join(' ')}</Tags>
+
+            <AiSummary>
+              <strong>AI 요약</strong>
+              <p>{summaryText}</p>
+            </AiSummary>
+
+            <MetaRow>
+              <MetaItem><Star01 size={19} fill="currentColor" /> {store.rating}</MetaItem>
+              <MetaItem>리뷰 {store.reviewCount}</MetaItem>
+              <MetaItem><Heart size={19} /> {store.likeCount}</MetaItem>
+              <MetaItem><MarkerPin01 size={19} /> {store.distance}</MetaItem>
+              {store.isDelivery && <UnderlinedMetaItem>배달 가능</UnderlinedMetaItem>}
+            </MetaRow>
+            
+            <ActionRow>
+              <ActionButton variant="subsidiary" onClick={handleOpenModal}><Phone size={17} />전화</ActionButton>
+              <ActionButton variant="subsidiary"><Heart size={17} />찜</ActionButton>
+              <ActionButton variant="subsidiary"><Share01 size={17} />공유</ActionButton>
+            </ActionRow>
+          </InfoWrapper>
+        </Container>
+      </Section>
+
+      {isModalOpen && (
+        <PhoneNumberModalBackdrop>
+          <PhoneNumberModalContent>
+            <PhoneNumberModalCloseButton onClick={handleCloseModal}>
+              <XClose size={18} />
+            </PhoneNumberModalCloseButton>
+            <PhoneNumberModalText>전화번호 : {store.phone}</PhoneNumberModalText>
+            <PhoneNumberModalCopyLink onClick={handleCopyPhoneNumber}>복사</PhoneNumberModalCopyLink>
+          </PhoneNumberModalContent>
+        </PhoneNumberModalBackdrop>
+      )}
+    </>
+  );
+}

--- a/src/components/StoreDetail/StoreDetailHeader/StoreDetailHeader.jsx
+++ b/src/components/StoreDetail/StoreDetailHeader/StoreDetailHeader.jsx
@@ -101,7 +101,6 @@ const MetaItem = styled.span`
 `;
 const UnderlinedMetaItem = styled(MetaItem)`
   text-decoration: underline;
-  cursor: pointer;
   font-size: 15px;
 `;
 const ActionRow = styled.div`

--- a/src/components/StoreDetail/StoreDetailHeader/index.js
+++ b/src/components/StoreDetail/StoreDetailHeader/index.js
@@ -1,0 +1,1 @@
+export { StoreDetailHeader } from './StoreDetailHeader';

--- a/src/components/StoreDetail/StoreDetailInfo/StoreDetailInfo.jsx
+++ b/src/components/StoreDetail/StoreDetailInfo/StoreDetailInfo.jsx
@@ -1,0 +1,103 @@
+// --- 라이브러리 ---
+import React, { useState } from 'react';
+import styled from '@emotion/styled';
+import { ChevronDown } from '@untitledui/icons';
+
+// --- 내부 (부모) ---
+import { Card } from '../../common';
+
+// --- 스타일 ---
+const InfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px 48px;
+  background-color: #f9fafb;
+`;
+
+const InfoCard = styled(Card)`
+  padding: 24px;
+`;
+
+const Title = styled.h3`
+  margin: 0 0 8px;
+  font-size: 16px;
+  color: ${({ theme }) => theme.colors.blue};
+`;
+
+const Content = styled.p`
+  margin: 0;
+  font-size: 14px;
+  color: #333;
+`;
+
+const HoursToggle = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+`;
+
+const HoursDetail = styled.div`
+  padding-left: 18px;
+  font-size: 12px;
+  color: #555;
+  line-height: 1.8;
+`;
+
+// --- 더미 데이터 ---
+const dummyInfo = {
+  address: '인천 미추홀구 인하로 73-1 1층',
+  hours: {
+    summary: '영업 종료 - 21:00에 영업 종료',
+    detail: {
+      '월요일': '11:00 - 21:00',
+      '화요일': '11:00 - 21:00',
+      '수요일': '11:00 - 21:00',
+      '목요일': '11:00 - 21:00',
+      '금요일': '11:00 - 21:00',
+      '토요일': '11:00 - 21:00',
+      '일요일': '11:00 - 21:00',
+    }
+  },
+  additional: {
+    '홈페이지': 'example.com',
+    '포장': '가능',
+    '배달': '가능',
+  }
+};
+
+export function StoreDetailInfo() {
+  const [isHoursOpen, setIsHoursOpen] = useState(false);
+
+  return (
+    <InfoContainer>
+      <InfoCard>
+        <Title>주소</Title>
+        <Content>{dummyInfo.address}</Content>
+      </InfoCard>
+
+      <InfoCard>
+        <Title>영업시간</Title>
+        <HoursToggle onClick={() => setIsHoursOpen(prev => !prev)}>
+          <Content>{dummyInfo.hours.summary}</Content>
+          <ChevronDown size={16} style={{ transform: isHoursOpen ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }} />
+        </HoursToggle>
+        {isHoursOpen && (
+          <HoursDetail>
+            {Object.entries(dummyInfo.hours.detail).map(([day, time]) => (
+              <div key={day}>{day}: {time}</div>
+            ))}
+          </HoursDetail>
+        )}
+      </InfoCard>
+
+      <InfoCard>
+        <Title>부가정보</Title>
+        {Object.entries(dummyInfo.additional).map(([key, value]) => (
+          <Content key={key} style={{ marginTop: '4px' }}>{key}: {value}</Content>
+        ))}
+      </InfoCard>
+    </InfoContainer>
+  );
+}

--- a/src/components/StoreDetail/StoreDetailInfo/StoreDetailInfo.jsx
+++ b/src/components/StoreDetail/StoreDetailInfo/StoreDetailInfo.jsx
@@ -11,23 +11,24 @@ const InfoContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 16px;
-  padding: 24px 48px;
+  padding: 24px 340px; 
   background-color: #f9fafb;
 `;
 
 const InfoCard = styled(Card)`
-  padding: 24px;
+  /* 상하 여백은 18px, 좌우 여백은 24px로 조정합니다. */
+  padding: 18px 24px; 
 `;
 
 const Title = styled.h3`
   margin: 0 0 8px;
-  font-size: 16px;
+  font-size: 19px;
   color: ${({ theme }) => theme.colors.blue};
 `;
 
 const Content = styled.p`
   margin: 0;
-  font-size: 14px;
+  font-size: 16px;
   color: #333;
 `;
 
@@ -39,10 +40,11 @@ const HoursToggle = styled.div`
 `;
 
 const HoursDetail = styled.div`
-  padding-left: 18px;
-  font-size: 12px;
+  padding-left: 71px;
+  font-size: 14px;
   color: #555;
   line-height: 1.8;
+  margin-top: 8px;
 `;
 
 // --- 더미 데이터 ---

--- a/src/components/StoreDetail/StoreDetailInfo/index.js
+++ b/src/components/StoreDetail/StoreDetailInfo/index.js
@@ -1,0 +1,1 @@
+export { StoreDetailInfo } from './StoreDetailInfo';

--- a/src/components/StoreDetail/StoreDetailTabs/StoreDetailTabs.jsx
+++ b/src/components/StoreDetail/StoreDetailTabs/StoreDetailTabs.jsx
@@ -1,0 +1,45 @@
+// --- 라이브러리 ---
+import React from 'react';
+import styled from '@emotion/styled';
+
+// --- 스타일 ---
+const TabContainer = styled.div`
+  display: flex;
+  border-bottom: 1px solid #e5e7eb;
+  padding-left: 470px; 
+`;
+
+const TabButton = styled.button`
+  padding: 12px 30px; /* ◀ 버튼의 상하좌우 여백을 늘렸습니다 */
+  font-size: 21px; 
+  font-weight: 600;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: ${({ theme, active }) => (active ? theme.colors.blue : theme.colors.darkGray)};
+  border-bottom: 3.3px solid ${({ theme, active }) => (active ? theme.colors.blue : 'transparent')}; /* ◀ 아래 파란 선 두께를 키웠습니다 */
+  margin-bottom: -1px;
+`;
+
+const TABS = ['정보', '메뉴', '리뷰'];
+
+/**
+ * @param {object} props
+ * @param {string} props.activeTab - 현재 활성화된 탭
+ * @param {function} props.setActiveTab - 탭 변경 핸들러
+ */
+export function StoreDetailTabs({ activeTab, setActiveTab }) {
+  return (
+    <TabContainer>
+      {TABS.map(tab => (
+        <TabButton
+          key={tab}
+          active={activeTab === tab}
+          onClick={() => setActiveTab(tab)}
+        >
+          {tab}
+        </TabButton>
+      ))}
+    </TabContainer>
+  );
+}

--- a/src/components/StoreDetail/StoreDetailTabs/index.js
+++ b/src/components/StoreDetail/StoreDetailTabs/index.js
@@ -1,0 +1,1 @@
+export { StoreDetailTabs } from './StoreDetailTabs';

--- a/src/components/StoreDetail/index.js
+++ b/src/components/StoreDetail/index.js
@@ -1,0 +1,3 @@
+export { StoreDetailHeader } from './StoreDetailHeader';
+export { StoreDetailTabs } from './StoreDetailTabs';
+export { StoreDetailInfo } from './StoreDetailInfo';

--- a/src/pages/StoreDetail/index.jsx
+++ b/src/pages/StoreDetail/index.jsx
@@ -1,25 +1,22 @@
 // --- 라이브러리 ---
-import React from 'react';
+import React, { useState } from 'react';
 
 // --- 내부 (부모) ---
-import { StoreCard } from '../../components/Store';
+import { StoreDetailHeader, StoreDetailTabs, StoreDetailInfo } from '../../components/StoreDetail';
 
 // --- 페이지 엔트리 (Default Export 허용) ---
-export default function Stores() {
+export default function StoreDetail() {
+  const [activeTab, setActiveTab] = useState('정보');
+
   return (
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        padding: '48px',
-        backgroundColor: '#f8f9fa',
-      }}
-    >
-      <div style={{ width: '320px' }}>
-        {/* props 없이 호출하면 설정된 기본 데이터가 보입니다 */}
-        <StoreCard />
-      </div>
-    </div>
+    <main>
+      <StoreDetailHeader />
+      <StoreDetailTabs activeTab={activeTab} setActiveTab={setActiveTab} />
+      
+      {/* 현재 활성화된 탭에 따라 다른 내용을 보여줍니다 */}
+      {activeTab === '정보' && <StoreDetailInfo />}
+      {activeTab === '메뉴' && <div style={{ padding: 48 }}>메뉴 컴포넌트가 여기에 표시됩니다.</div>}
+      {activeTab === '리뷰' && <div style={{ padding: 48 }}>리뷰 컴포넌트가 여기에 표시됩니다.</div>}
+    </main>
   );
 }


### PR DESCRIPTION
완료된 것:
가게 상세 페이지에 사용할 컴포넌트 중
1. 가게 상세 헤더
2. 정보/메뉴/리뷰 탭
3. 정보 탭 내용
가게상세페이지에 구현 완료 했습니다. (더미데이터 사용)
<img width="1867" height="987" alt="image" src="https://github.com/user-attachments/assets/1307044e-e03d-407d-b8be-8d8a45702bc8" />

해야할 거: 
메뉴 탭 내용, 가게 상세 헤더에 있는 버튼 세 개 중(아래 이미지 참고) 찜이랑 공유 버튼 기능 개발해야 합니다 (버튼 기능은 개발하다가 오류 생겨서 아예 내용 지우고 올립니다)
<img width="375" height="78" alt="image" src="https://github.com/user-attachments/assets/2d6adc72-edfd-4f6f-b0db-45e716e5a486" />

그리고 정보/메뉴/리뷰 탭은 개인적으로 만든 컴포넌트로 사용했습니다! 공용 컴포넌트로 아직 바꾸진 못했습니다
<img width="539" height="113" alt="image" src="https://github.com/user-attachments/assets/24d6d65e-60f9-48a5-9ab1-72bc6e8bca43" />

