### PR TITLE
feat: 카카오맵 API 연동 및 맵 표시 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env

--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
+
+    <script
+      type="text/javascript"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAO_MAP_API_KEY%&libraries=services"
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/hooks/useKakaoMap.js
+++ b/src/hooks/useKakaoMap.js
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * 카카오 지도를 생성하고 관리하는 커스텀 훅
+ * @param {object} options - 지도 생성에 필요한 옵션 (center: { lat, lng }, level 등)
+ * @returns {object} - 지도를 렌더링할 DOM 요소에 연결할 ref 객체
+ */
+export function useKakaoMap(options) {
+  const mapContainerRef = useRef(null);
+
+  useEffect(() => {
+    if (window.kakao && window.kakao.maps && mapContainerRef.current) {
+      // options 객체에서 위도, 경도를 가져와 LatLng 객체 생성
+      const mapOption = {
+        center: new window.kakao.maps.LatLng(
+          options.center.lat,
+          options.center.lng
+        ),
+        level: options.level,
+      };
+
+      // 지도 생성
+      const map = new window.kakao.maps.Map(mapContainerRef.current, mapOption);
+    }
+  }, [options]); // options가 변경되면 지도를 다시 그림
+
+  return { mapContainerRef };
+}

--- a/src/pages/Map/index.jsx
+++ b/src/pages/Map/index.jsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import { ListPannel } from '../../components/Map/ListPannel';
 import { MapsPageSidebar } from '../../layouts/MapsPageSidebar';
+import { useKakaoMap } from '../../hooks/useKakaoMap';
 
 // 페이지 전체를 감싸는 컨테이너. 모든 자식 요소들의 위치 기준점
 const StyledPageContainer = styled.div`
@@ -10,6 +11,16 @@ const StyledPageContainer = styled.div`
   width: 100vw;
   height: 100vh;
   overflow: hidden;
+`;
+
+// 지도를 담을 컨테이너 스타일
+const MapWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 0;
 `;
 
 const StyledMapPlaceholder = styled.div`
@@ -28,6 +39,18 @@ const StyledMapPlaceholder = styled.div`
 
 export default function MapPage() {
   const [activePanelId, setActivePanelId] = useState('map');
+
+  const mapOptions = {
+    center: {
+      lat: 37.45101, // 위도
+      lng: 126.6565, // 경도
+    },
+    level: 3,
+  };
+
+  //커스텀 훅을 호출하여 지도 컨테이너 ref를 받아옵니다.
+  const { mapContainerRef } = useKakaoMap(mapOptions);
+
   const handleMenuChange = menuId => {
     setActivePanelId(menuId);
     console.log('선택된 메뉴:', menuId); // 확인용
@@ -35,7 +58,7 @@ export default function MapPage() {
 
   return (
     <StyledPageContainer>
-      <StyledMapPlaceholder>지도 표시 예정.</StyledMapPlaceholder>
+      <MapWrapper ref={mapContainerRef} />
       <MapsPageSidebar onMenuChange={handleMenuChange} />
       <ListPannel activePanel={activePanelId} />
     </StyledPageContainer>


### PR DESCRIPTION
카카오맵 API를 통해서 맵 페이지에 지도를 구현했습니다.
hooks에 useKakaoMap.js 를 통해 지도를 사용할 수 있습니다.

이후 지도에서 검색했을 때 맵에 표시되는 기능을 구현할 예정입니다.