### PR TITLE
feat:가게 API 연결 및 카테고리 수정

### DIFF
--- a/src/entities/category/data/categories.js
+++ b/src/entities/category/data/categories.js
@@ -1,8 +1,11 @@
 export const CATEGORIES = [
-  { value: '한식', label: '한식' },
-  { value: '중식', label: '중식' },
-  { value: '일식', label: '일식' },
-  { value: '양식', label: '양식' },
-  { value: '분식', label: '분식' },
-  { value: '카페', label: '카페' },
+  { value: null, label: '전체' },
+  { value: 'korean', label: '한식' },
+  { value: 'chinese', label: '중식' },
+  { value: 'japanese', label: '일식' },
+  { value: 'western', label: '양식' },
+  { value: 'snack', label: '분식' },
+  { value: 'cafe', label: '카페' },
+  { value: 'bar', label: '술/안주' },
+  { value: 'others', label: '기타' },
 ];

--- a/src/entities/category/ui/CategoryTab.jsx
+++ b/src/entities/category/ui/CategoryTab.jsx
@@ -25,21 +25,18 @@ const TabButton = styled.button`
     border-color: ${({ isActive }) => (isActive ? 'none' : '#cbd5e1')};
   }
 
-  /* Tablet */
   ${media.tablet} {
     padding: 12px 22px;
     font-size: 15px;
     border-radius: 10px;
   }
 
-  /* Mobile */
   ${media.mobile} {
     padding: 8px 14px;
     font-size: 13px;
     border-radius: 8px;
   }
 
-  /* Small Mobile */
   ${media.mobileS} {
     padding: 6px 10px;
     font-size: 12px;
@@ -49,7 +46,7 @@ const TabButton = styled.button`
 
 export const CategoryTab = ({ label, isActive, onClick }) => {
   return (
-    <TabButton isActive={isActive} onClick={onClick}>
+    <TabButton type="button" isActive={isActive} onClick={onClick}>
       {label}
     </TabButton>
   );

--- a/src/entities/shop/api/shopApi.js
+++ b/src/entities/shop/api/shopApi.js
@@ -1,31 +1,68 @@
-import { SHOPS } from '../data/shops';
+import { API_BASE_URL, API_ENDPOINTS } from '../../../shared/config/api';
 
-const delay = (ms = 200) => new Promise(resolve => setTimeout(resolve, ms));
-
-const normalizeShops = () => SHOPS.map(shop => ({ ...shop }));
-
-export const fetchShops = async ({ category } = {}) => {
-  await delay();
-  const shops = normalizeShops();
-
-  if (category && category !== '전체') {
-    return shops.filter(shop => shop.category === category);
-  }
-
-  return shops;
+const CATEGORY_MAP = {
+  '한식': 'korean',
+  '중식': 'chinese',
+  '일식': 'japanese',
+  '양식': 'western',
+  '분식': 'snack',
+  '술/안주': 'bar',
+  '카페': 'cafe',
+  '기타': 'others',
 };
 
+// [GET] 가게 목록 조회
+export const fetchShops = async ({ category } = {}) => {
+  const apiCategory =
+    category && category !== '전체'
+      ? CATEGORY_MAP[category]
+      : null;
+
+  const query = apiCategory ? `?category=${apiCategory}` : '';
+
+  const response = await fetch(
+    `${API_BASE_URL}${API_ENDPOINTS.SHOPS}${query}`
+  );
+
+  if (!response.ok) {
+    throw new Error('가게 목록을 불러오지 못했습니다.');
+  }
+
+  const data = await response.json();
+
+  return data.stores.map(store => ({
+    id: store.id,
+    name: store.name,
+    category: store.category,   // 서버에서 내려주는 값 그대로
+    image: store.thumbnail,
+  }));
+};
+
+
+ // [GET] 가게 상세 조회
 export const fetchShopById = async id => {
   if (!id) {
     throw new Error('가게 ID가 필요합니다.');
   }
 
-  await delay(120);
-  const shop = normalizeShops().find(item => item.id === id);
+  const response = await fetch(
+    `${API_BASE_URL}${API_ENDPOINTS.SHOP_DETAIL(id)}`
+  );
 
-  if (!shop) {
-    throw new Error('해당 가게를 찾을 수 없어요.');
+  if (!response.ok) {
+    if (response.status === 404) {
+      throw new Error('해당 가게를 찾을 수 없어요.');
+    }
+    throw new Error('가게 정보를 불러오지 못했습니다.');
   }
 
-  return shop;
+  const data = await response.json();
+
+  return {
+    id: data.id,
+    name: data.name,
+    category: data.category,
+    phone: data.tel,  
+    address: data.address,
+  };
 };

--- a/src/entities/shop/ui/ShopCard.jsx
+++ b/src/entities/shop/ui/ShopCard.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { media } from '@shared/config/media';
 import { Card } from '@shared/ui/Card/Card';
-import { Badge } from '@shared/ui/Badge/Badge';
 import { Button } from '@shared/ui/Button/Button';
-import { Phone, Map01, Clock } from '@untitledui/icons';
+import { Phone, Map01 } from '@untitledui/icons';
+import defaultFoodImage from '../../../shared/assets/image/food.webp';
 
 /* ShopCard (리스트용) */
 
@@ -109,38 +109,6 @@ const Title = styled.h3`
   }
 `;
 
-const Description = styled.p`
-  margin: 8px 0 0;
-  font-size: 15px;
-  line-height: 22px;
-  color: #4b5563;
-
-  min-height: calc(22px * 2);
-
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-
-  ${media.mobile} {
-    font-size: 14px;
-    line-height: 20px;
-    min-height: calc(20px * 2);
-  }
-
-  ${media.mobileS} {
-    font-size: 13px;
-    line-height: 18px;
-    min-height: calc(18px * 2);
-  }
-`;
-
-const Highlights = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-`;
-
 const DetailButton = styled(Button)`
   margin-top: auto;
   padding: 12px 0;
@@ -164,34 +132,19 @@ export const ShopCard = ({ shop, onSelect }) => {
 
   return (
     <CardWrapper padding="0">
-      {shop.image && (
-        <ImageWrapper>
-          <img src={shop.image} alt={shop.name} />
-          <CategoryTag>{shop.category}</CategoryTag>
-        </ImageWrapper>
-      )}
+      <ImageWrapper> 
+        <img src={shop.thumbnail || defaultFoodImage} 
+        alt={shop.name} 
+        /> 
+        <CategoryTag>
+          {shop.category}
+        </CategoryTag> 
+      </ImageWrapper>
 
       <Content>
         <div>
           <Title>{shop.name}</Title>
-          <Description>{shop.description}</Description>
         </div>
-
-        {Array.isArray(shop.highlights) && shop.highlights.length > 0 && (
-          <Highlights>
-            {shop.highlights.map(h => (
-              <Badge
-                key={h}
-                variant="secondary"
-                size="small"
-                backgroundColor="#eaf2ff"
-                color="#27509B"
-              >
-                #{h}
-              </Badge>
-            ))}
-          </Highlights>
-        )}
 
         <DetailButton variant="primary" onClick={() => onSelect?.(shop)}>
           자세히 보기
@@ -271,7 +224,6 @@ export const ShopDetailInfo = ({ shop }) => {
   const infoRows = [
     { label: '전화번호', value: shop.phone || '정보 준비 중', Icon: Phone },
     { label: '주소', value: shop.address || '정보 준비 중', Icon: Map01 },
-    { label: '영업시간', value: shop.hours || '정보 준비 중', Icon: Clock },
   ];
 
   return (

--- a/src/pages/shop-list/ui/ShopListPage.jsx
+++ b/src/pages/shop-list/ui/ShopListPage.jsx
@@ -1,23 +1,26 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+
 import { CATEGORIES } from '@entities/category/data/categories';
 import { CategoryTab } from '@entities/category/ui/CategoryTab';
 import { ShopListView } from '@widgets/shop-list-view';
 import { fetchShops } from '@entities/shop/api/shopApi';
-import { Card, Grid, Button } from '@shared/ui';
-import { Spinner } from '@shared/ui/Spinner';
 
-const ALL_CATEGORY = '전체';
+import { Card } from '@shared/ui';
+import { Spinner } from '@shared/ui/Spinner';
 
 const ShopListPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
+  const [activeCategory, setActiveCategory] = useState(null);
   const [shops, setShops] = useState([]);
-  const [activeCategory, setActiveCategory] = useState(ALL_CATEGORY);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
 
+  /**
+   * URL 쿼리 (?c=korean) → 상태 동기화
+   */
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     const categoryFromQuery = params.get('c');
@@ -25,12 +28,16 @@ const ShopListPage = () => {
     if (categoryFromQuery) {
       setActiveCategory(categoryFromQuery);
     } else {
-      setActiveCategory(ALL_CATEGORY);
+      setActiveCategory(null);
     }
   }, [location.search]);
 
+  /**
+   * 가게 목록 조회
+   */
   useEffect(() => {
     setIsLoading(true);
+
     fetchShops()
       .then(data => {
         setShops(data);
@@ -42,23 +49,33 @@ const ShopListPage = () => {
       .finally(() => setIsLoading(false));
   }, []);
 
+  /**
+   * 카테고리 필터링
+   */
   const filteredShops = useMemo(() => {
-    if (activeCategory === ALL_CATEGORY) {
-      return shops;
-    }
+    if (!activeCategory) return shops;
     return shops.filter(shop => shop.category === activeCategory);
   }, [shops, activeCategory]);
 
+  /**
+   * 카테고리 변경 핸들러
+   */
   const handleCategoryChange = categoryValue => {
     setActiveCategory(categoryValue);
+
     const params = new URLSearchParams();
-    if (categoryValue !== ALL_CATEGORY) {
+    if (categoryValue) {
       params.set('c', categoryValue);
     }
-    const query = params.toString();
-    navigate(`/shops${query ? `?${query}` : ''}`, { replace: true });
+
+    navigate(`/shops${params.toString() ? `?${params}` : ''}`, {
+      replace: true,
+    });
   };
 
+  /**
+   * 가게 선택 → 상세 페이지 이동
+   */
   const handleSelectShop = shop => {
     navigate(`/shops/${shop.id}`);
   };
@@ -74,21 +91,19 @@ const ShopListPage = () => {
           gap: '32px',
         }}
       >
+        {/* ===== 카테고리 탭 ===== */}
         <Card variant="default" padding="20px">
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: '12px' }}>
-            {[ALL_CATEGORY, ...CATEGORIES.map(category => category.value)].map(
-              categoryValue => (
-                <CategoryTab
-                  key={categoryValue}
-                  label={categoryValue}
-                  isActive={activeCategory === categoryValue}
-                  onClick={() => handleCategoryChange(categoryValue)}
-                />
-              )
-            )}
+            {CATEGORIES.map(category => (
+              <CategoryTab
+                key={category.value ?? 'all'}
+                label={category.label}              
+                isActive={activeCategory === category.value}
+                onClick={() => handleCategoryChange(category.value)}
+              />
+            ))}
           </div>
         </Card>
-
         {error && (
           <Card variant="default" padding="20px">
             <p
@@ -103,7 +118,6 @@ const ShopListPage = () => {
             </p>
           </Card>
         )}
-
         <Card padding="0">
           {isLoading ? (
             <div

--- a/src/shared/config/api.js
+++ b/src/shared/config/api.js
@@ -2,6 +2,10 @@ export const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
 
 export const API_ENDPOINTS = {
+  // 가게 목록, 상세 정보 조회
+  SHOPS: '/api/v1/shops',
+  SHOP_DETAIL: id => `/api/v1/shops/${id}`,
+
   RANDOM_NICKNAME: '/api/v1/reviews/nickname',
   SHOP_REVIEWS: shopId => `/api/v1/shops/${shopId}/reviews`,
   ROULETTE_OPTIONS: '/api/v1/roulette/options',

--- a/src/widgets/home-banner/ui/HomeBanner.jsx
+++ b/src/widgets/home-banner/ui/HomeBanner.jsx
@@ -78,7 +78,7 @@ const LogoImage = styled.img`
   opacity: 0.9;
   filter: brightness(0) invert(1);
   pointer-events: none;
-  zindex: 1;
+  z-index: 1;
 
   ${media.tablet} {
     height: 200px;
@@ -136,7 +136,9 @@ export const HomeBanner = () => {
             justifyContent: 'center',
           }}
         >
-          {CATEGORIES.map(category => (
+          {CATEGORIES
+          .filter(category => category.value !== null)
+          .map(category => (
             <CategoryTab
               key={category.value}
               label={category.label}


### PR DESCRIPTION
#### 1. 가게 API 연동
- 가게 목록 조회 API 연동
- 가게 상세 정보 조회 API 연동
- 목록 → 상세 페이지 & 룰렛 → 상세 페이지 이동 시 실제 API 데이터를 기반으로 화면 렌더링

#### 2. 카테고리 필터 구조와 ui 수정
- 카테고리 값을 한글 → 영문 기준으로 통일
- 카테고리 탭 UI는 `label(한글)` / 내부 로직은 `value(영문)` 구조로 분리
- URL 쿼리(`?c=korean`)와 카테고리 상태를 동기화
- 카테고리 목록 추가