### PR TITLE
fix: 리뷰 날짜 KST(한국 시간) 변환 오류 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,13 +2,20 @@
 <html lang="en">
   <head>
     <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-592LPQPB');</script>
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-592LPQPB');
+    </script>
     <!-- End Google Tag Manager -->
-    
+
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -27,10 +34,16 @@
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-592LPQPB"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <noscript
+      ><iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-592LPQPB"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      ></iframe
+    ></noscript>
     <!-- End Google Tag Manager (noscript) -->
-    
+
     <div id="root"></div>
     <script type="module" src="/src/app/index.jsx"></script>
   </body>

--- a/src/shared/lib/date.js
+++ b/src/shared/lib/date.js
@@ -1,4 +1,6 @@
 export const formatDate = (date, locale = 'ko-KR') => {
   if (!date) return '';
-  return new Intl.DateTimeFormat(locale).format(new Date(date));
+  const d = new Date(date);
+  d.setHours(d.getHours() + 9); //+ 9시간(한국 표준시)
+  return new Intl.DateTimeFormat(locale).format(d);
 };


### PR DESCRIPTION
lib/date.js 파일에서 시간이 9시간이 추가되도록 수정하였습니다.
(UTC -> KST 한국 시간 보정)